### PR TITLE
proxy: add lua operation label in backend proxy event logs

### DIFF
--- a/logger.c
+++ b/logger.c
@@ -441,7 +441,7 @@ static void _logger_log_proxy_errbe(logentry *e, const entry_details *d, const v
     memcpy(data, be_port, le->be_portlen);
     data += le->be_portlen;
     memcpy(data, be_label, le->be_labellen);
-    data += le->be-labellen;
+    data += le->be_labellen;
     memcpy(data, be_rbuf, le->be_rbuflen);
     data += le->be_rbuflen;
 

--- a/logger.c
+++ b/logger.c
@@ -469,13 +469,13 @@ static int _logger_parse_prx_errbe(logentry *e, char *scratch) {
                 "ts=%lld.%d gid=%llu type=proxy_backend error=%.*s name=%.*s port=%.*s label=%.*s retry=%d\n",
                 (long long int)e->tv.tv_sec, (int)e->tv.tv_usec, (unsigned long long) e->gid,
                 (int)le->errlen, errmsg, (int)le->be_namelen, be_name,
-                (int)le->be_portlen, be_port, be_label, le->retry);
+                (int)le->be_portlen, be_port, (int)le->be_labellen, be_label, le->retry);
     } else {
         total = snprintf(scratch, LOGGER_PARSE_SCRATCH,
                 "ts=%lld.%d gid=%llu type=proxy_backend error=%.*s name=%.*s port=%.*s label=%.*s depth=%d rbuf=%s\n",
                 (long long int)e->tv.tv_sec, (int)e->tv.tv_usec, (unsigned long long) e->gid,
                 (int)le->errlen, errmsg, (int)le->be_namelen, be_name,
-                (int)le->be_portlen, be_port, be_label, le->be_depth, rbuf);
+                (int)le->be_portlen, be_port, (int)le->be_labellen, be_label, le->be_depth, rbuf);
     }
 
     return total;

--- a/logger.c
+++ b/logger.c
@@ -409,6 +409,7 @@ static void _logger_log_proxy_errbe(logentry *e, const entry_details *d, const v
     char *errmsg = va_arg(ap, char *);
     char *be_name = va_arg(ap, char *);
     char *be_port = va_arg(ap, char *);
+    char *be_label = va_arg(ap, char *);
     int be_depth = va_arg(ap, int);
     char *be_rbuf = va_arg(ap, char *);
     int be_rbuflen = va_arg(ap, int);
@@ -423,6 +424,10 @@ static void _logger_log_proxy_errbe(logentry *e, const entry_details *d, const v
         le->be_portlen = strlen(be_port);
     }
 
+    if (be_label) {
+        le->be_labellen = strlen(be_label);
+    }
+
     le->be_rbuflen = be_rbuflen;
     if (be_rbuflen > MAX_RBUF_READ) {
         le->be_rbuflen = MAX_RBUF_READ;
@@ -435,6 +440,8 @@ static void _logger_log_proxy_errbe(logentry *e, const entry_details *d, const v
     data += le->be_namelen;
     memcpy(data, be_port, le->be_portlen);
     data += le->be_portlen;
+    memcpy(data, be_label, le->be_labellen);
+    data += le->be-labellen;
     memcpy(data, be_rbuf, le->be_rbuflen);
     data += le->be_rbuflen;
 
@@ -452,21 +459,23 @@ static int _logger_parse_prx_errbe(logentry *e, char *scratch) {
     data += le->be_namelen;
     char *be_port = data;
     data += le->be_portlen;
+    char *be_label = data;
+    data += le->be_labellen;
     char *be_rbuf = data;
 
     uriencode(be_rbuf, rbuf, le->be_rbuflen, MAX_RBUF_READ * 3);
     if (le->retry) {
         total = snprintf(scratch, LOGGER_PARSE_SCRATCH,
-                "ts=%lld.%d gid=%llu type=proxy_backend error=%.*s name=%.*s port=%.*s retry=%d\n",
+                "ts=%lld.%d gid=%llu type=proxy_backend error=%.*s name=%.*s port=%.*s label=%.*s retry=%d\n",
                 (long long int)e->tv.tv_sec, (int)e->tv.tv_usec, (unsigned long long) e->gid,
                 (int)le->errlen, errmsg, (int)le->be_namelen, be_name,
-                (int)le->be_portlen, be_port, le->retry);
+                (int)le->be_portlen, be_port, be_label, le->retry);
     } else {
         total = snprintf(scratch, LOGGER_PARSE_SCRATCH,
-                "ts=%lld.%d gid=%llu type=proxy_backend error=%.*s name=%.*s port=%.*s depth=%d rbuf=%s\n",
+                "ts=%lld.%d gid=%llu type=proxy_backend error=%.*s name=%.*s port=%.*s label=%.*s depth=%d rbuf=%s\n",
                 (long long int)e->tv.tv_sec, (int)e->tv.tv_usec, (unsigned long long) e->gid,
                 (int)le->errlen, errmsg, (int)le->be_namelen, be_name,
-                (int)le->be_portlen, be_port, le->be_depth, rbuf);
+                (int)le->be_portlen, be_port, be_label, le->be_depth, rbuf);
     }
 
     return total;

--- a/logger.h
+++ b/logger.h
@@ -140,6 +140,7 @@ struct logentry_proxy_errbe {
     size_t errlen;
     size_t be_namelen;
     size_t be_portlen;
+    size_t be_labellen;
     size_t be_rbuflen;
     int be_depth;
     int retry;

--- a/proxy.h
+++ b/proxy.h
@@ -388,6 +388,7 @@ struct mcp_backend_s {
     io_head_t io_head; // stack of inbound requests.
     char name[MAX_NAMELEN+1];
     char port[MAX_PORTLEN+1];
+    char label[MAX_LABELLEN+1];
     struct proxy_tunables tunables; // this gets copied a few times for speed.
     struct mcp_backendconn_s be[];
 };

--- a/proxy_lua.c
+++ b/proxy_lua.c
@@ -404,6 +404,7 @@ static mcp_backend_wrap_t *_mcplib_make_backendconn(lua_State *L, mcp_backend_la
 
     strncpy(be->name, bel->name, MAX_NAMELEN+1);
     strncpy(be->port, bel->port, MAX_PORTLEN+1);
+    strncpy(be->label, bel->label, MAX_LABELLEN+1);
     memcpy(&be->tunables, &bel->tunables, sizeof(bel->tunables));
     be->conncount = bel->conncount;
     STAILQ_INIT(&be->io_head);

--- a/proxy_network.c
+++ b/proxy_network.c
@@ -773,7 +773,7 @@ static void _backend_reschedule(struct mcp_backendconn_s *be) {
         if (!be->bad) {
             P_DEBUG("%s: marking backend as bad\n", __func__);
             STAT_INCR(be->event_thread->ctx, backend_marked_bad, 1);
-            LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_BE_ERROR, NULL, badtext, be->be_parent->name, be->be_parent->port, 0, NULL, 0, retry_time);
+            LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_BE_ERROR, NULL, badtext, be->be_parent->name, be->be_parent->port, be->be_parent->label, 0, NULL, 0, retry_time);
         }
         be->bad = true;
         be->depth = INT_MAX/2; // fast-path cache for "bad" marker
@@ -856,7 +856,7 @@ static void _reset_bad_backend(struct mcp_backendconn_s *be, enum proxy_be_failu
 
     // Only log if we don't already know it's messed up.
     if (!be->bad) {
-        LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_BE_ERROR, NULL, proxy_be_failure_text[err], be->be_parent->name, be->be_parent->port, depth, be->rbuf, be->rbufused, 0);
+        LOGGER_LOG(NULL, LOG_PROXYEVENTS, LOGGER_PROXY_BE_ERROR, NULL, proxy_be_failure_text[err], be->be_parent->name, be->be_parent->port, be->be_parent->label, depth, be->rbuf, be->rbufused, 0);
     }
 
     // reset buffer to blank state.


### PR DESCRIPTION
### Background
The `label` field passed at the Lua layer, typically used to denote specifics about the given type of operation, is currently only stored in Lua memory and not stored in the internal backend struct. Therefore, proxy events concerning backend errors are currently unable to emit the label provided in Lua.

This change extracts the `label` provided by Lua and stores it in the backend struct. It then logs it as a proxy event whenever a backend failure takes place.  

### Tests
Manually tested by bringing down a single backend node and attempting a meta-get operation on a proxy node. Observed the following events emitted, with hostnames and ports omitted:
```
watch proxyevents
OK
ts=1696457089.21527 gid=6 type=proxy_backend error=disconnected name=[hostname] port=[port] label=[hostname]-read depth=0 rbuf=
ts=1696457089.21784 gid=7 type=proxy_backend error=connecting name=[hostname] port=[port] label=[hostname]-read depth=0 rbuf=
ts=1696457089.21980 gid=8 type=proxy_backend error=connecting name=[hostname] port=[port] label=[hostname]-read depth=0 rbuf=
ts=1696457089.22147 gid=9 type=proxy_backend error=connecting name=[hostname] port=[port] label=[hostname]-read depth=0 rbuf=
ts=1696457089.22150 gid=10 type=proxy_backend error=markedbad name=[hostname] port=[port] label=[hostname]-read retry=3
```